### PR TITLE
API: better user updating

### DIFF
--- a/api/datastore/store.go
+++ b/api/datastore/store.go
@@ -7,6 +7,7 @@ import (
 type DBClient interface {
 	InsertUser(ctx context.Context, first, id, last, username string) error
 	QueryUserByID(context.Context, string) (User, error)
+	UpdateUser(ctx context.Context, first, id, last, username string) error
 }
 
 type DataStore struct {

--- a/api/datastore/user.go
+++ b/api/datastore/user.go
@@ -3,14 +3,13 @@ package datastore
 import (
 	"context"
 
-	"github.com/google/uuid"
 	"github.com/rusher2004/job-board/api/server"
 )
 
 type User struct {
 	FirstName string
 	LastName  string
-	ID        uuid.UUID
+	ID        string
 	Username  string
 }
 
@@ -39,6 +38,6 @@ func (d DataStore) GetUserList(ctx context.Context, in server.GetUserListInput) 
 	return []server.UserMetadata{}, nil
 }
 
-func (d DataStore) PutUser(ctx context.Context, in server.PutUserInput) (server.UserMetadata, error) {
-	return server.UserMetadata{}, nil
+func (d DataStore) PutUser(ctx context.Context, first, id, last, username string) error {
+	return d.db.UpdateUser(ctx, first, id, last, username)
 }

--- a/api/identity/identity.go
+++ b/api/identity/identity.go
@@ -4,20 +4,27 @@ import (
 	"fmt"
 
 	"github.com/rusher2004/job-board/api/server"
-	"github.com/supertokens/supertokens-golang/recipe/thirdpartyemailpassword"
+	ev "github.com/supertokens/supertokens-golang/recipe/emailverification"
+	tpep "github.com/supertokens/supertokens-golang/recipe/thirdpartyemailpassword"
 )
 
 type IdentityStore struct{}
 
 func (i IdentityStore) GetUser(id string) (server.UserIdentity, error) {
-	u, err := thirdpartyemailpassword.GetUserById(id)
+	u, err := tpep.GetUserById(id)
 	if err != nil {
 		return server.UserIdentity{}, fmt.Errorf("error getting user: %w", err)
 	}
 
+	v, err := ev.IsEmailVerified(id, &u.Email)
+	if err != nil {
+		return server.UserIdentity{}, fmt.Errorf("error getting email verification status: %w", err)
+	}
+
 	return server.UserIdentity{
 		Email: server.Email{
-			Address: u.Email,
+			Address:  u.Email,
+			Verified: v,
 		},
 		ID: u.ID,
 	}, nil

--- a/api/server/middlewares.go
+++ b/api/server/middlewares.go
@@ -62,9 +62,9 @@ func withUserSession(required bool) func(http.Handler) http.Handler {
 	}
 }
 
-// withAccountOwner will validate that the user id in the request context is the same account as the
+// withResourceOwner will validate that the user id in the request context is the same account as the
 // named resource. It must be used after withUserSession.
-func (s *Server) withAccountOwner(param string) func(http.Handler) http.Handler {
+func (s *Server) withResourceOwner(param string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()

--- a/api/server/middlewares.go
+++ b/api/server/middlewares.go
@@ -2,8 +2,11 @@ package server
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/supertokens/supertokens-golang/recipe/session"
 	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
 	"github.com/supertokens/supertokens-golang/supertokens"
@@ -55,6 +58,52 @@ func withUserSession(required bool) func(http.Handler) http.Handler {
 
 			// no session, continue
 			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// withAccountOwner will validate that the user id in the request context is the same account as the
+// named resource. It must be used after withUserSession.
+func (s *Server) withAccountOwner(param string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			id := *ContextValue[string](ctx, userIDCTXKey)
+
+			p := chi.URLParam(r, param)
+			if p == "" {
+				hErr := HTTPError{http.StatusBadRequest, fmt.Sprintf("missing {%s} parameter", param)}
+				respond(w, r, nil, hErr, hErr.status)
+				return
+			}
+
+			u, err := s.dataStore.GetUser(ctx, GetUserInput{ID: id})
+			if err != nil {
+				respond(w, r, nil, err, 0)
+				return
+			}
+
+			b, err := json.Marshal(u)
+			if err != nil {
+				hErr := HTTPError{http.StatusInternalServerError, "error marshalling accountOwner data"}
+				respond(w, r, nil, hErr, hErr.status)
+				return
+			}
+
+			var m map[string]any
+			if err := json.Unmarshal(b, &m); err != nil {
+				hErr := HTTPError{http.StatusInternalServerError, "error unmarshalling accountOwner data"}
+				respond(w, r, nil, hErr, hErr.status)
+				return
+			}
+
+			if m[param] != p {
+				hErr := HTTPError{http.StatusForbidden, "accountOwner does not match request"}
+				respond(w, r, nil, hErr, hErr.status)
+				return
+			}
+
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -25,7 +25,7 @@ type DataStore interface {
 	DeleteUser(context.Context, DeleteUserInput) error
 	GetUser(context.Context, GetUserInput) (UserMetadata, error)
 	GetUserList(context.Context, GetUserListInput) ([]UserMetadata, error)
-	PutUser(context.Context, PutUserInput) (UserMetadata, error)
+	PutUser(ctx context.Context, first, id, last, username string) error
 }
 
 type IdentityStore interface {
@@ -103,9 +103,12 @@ func (s *Server) routes() {
 
 		r.Route("/{username}", func(r chi.Router) {
 			r.Use(withUserSession(false))
-			r.Delete("/", s.handleDeleteUser)
 			r.Get("/", s.handleGetUser)
-			r.Put("/", s.handlePutUser)
+			r.Group(func(r chi.Router) {
+				r.Use(s.withAccountOwner("username"))
+				r.Delete("/", s.handleDeleteUser)
+				r.Put("/", s.handlePutUser)
+			})
 		})
 	})
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -105,7 +105,7 @@ func (s *Server) routes() {
 			r.Use(withUserSession(false))
 			r.Get("/", s.handleGetUser)
 			r.Group(func(r chi.Router) {
-				r.Use(s.withAccountOwner("username"))
+				r.Use(s.withResourceOwner("username"))
 				r.Delete("/", s.handleDeleteUser)
 				r.Put("/", s.handlePutUser)
 			})

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -83,7 +83,7 @@ export interface UserPostRequest {
 
 export const UserPutConfig = {
   method: 'PUT',
-  path: '/user/{:username}',
+  path: '/user/:username',
 };
 
 export interface UserPutRequest {


### PR DESCRIPTION
This PR adds some real functionality to API user operations.

- the `withResourceOwner` middleware now allows for a route to fail if the requesting user owns the given resource.
- `PUT /user/{username}` now actually puts
- UpdateUser function added to db package

## Testing with user `rusher2`

Successful call to `PUT /user/rusher2`

```sh
curl 'http://localhost:8080/user/rusher2' \
  -X 'PUT' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Cookie: sAccessToken=eyJraWQiOiJkLTE3MTMwMjIyNDI5NjQiLCJ0eXAiOiJKV1QiLCJ2ZXJzaW9uIjoiNCIsImFsZyI6IlJTMjU2In0.eyJpYXQiOjE3MTMyNDUxNzgsImV4cCI6MTcxMzI0ODY1OSwic3ViIjoiNjlmNDcxMjgtZDBjZS00NmQ2LTk4NjUtYjkzMGQ1ZWUxNDQ4IiwidElkIjoicHVibGljIiwic2Vzc2lvbkhhbmRsZSI6ImUxZWIzZjM2LTU1NDAtNDM5OS05NGE5LTE0YTFlODcwMDk0NiIsInJlZnJlc2hUb2tlbkhhc2gxIjoiY2QyMTBjMDNhYjJmYTRkMzAzYWNjMWY4ZDIwYzcwYmZmNTBiM2ViOTMzOTEzMWIwZDBhYThmNzg0NmZkYmVhZCIsInBhcmVudFJlZnJlc2hUb2tlbkhhc2gxIjpudWxsLCJhbnRpQ3NyZlRva2VuIjpudWxsLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvYXV0aCIsInN0LWV2Ijp7InQiOjE3MTMyNDUxNzg4NDksInYiOnRydWV9fQ.R8A9dvAgHruEsLC83W1oSqrPjGWWReuLmW6kRpR58s3xiKUnVBj5dF6gGzpORdPMd3qhgo0rKR7prNc_6uH6JOosplENqkoyceC1yGzIDtIe0ppaK222GAE3BHxakEO167_qP9gu2aZU_u5SnqILzj3iG2VtcroDaDgosFot_y8-bJzY6KnlVgEhftqV2jiyrNYB_p-3hQ4YtaF0ELFeZzNTqmFy7iWzh-_D4Z6lxaUjkAay24P7ZdmiSeEppLdcVZL9jvM_MsPSj-o9ILW_jzmGPRhsCRo4ufDdJhZYvT2QvnkcNRM1BuZ-9s5VQRslMwMPAXw2ATdB0YOROOQJKg; st-last-access-token-update=1713245179111; sFrontToken=eyJ1aWQiOiI2OWY0NzEyOC1kMGNlLTQ2ZDYtOTg2NS1iOTMwZDVlZTE0NDgiLCJhdGUiOjE3MTMyNDg2NTkwMDAsInVwIjp7ImFudGlDc3JmVG9rZW4iOm51bGwsImV4cCI6MTcxMzI0ODY1OSwiaWF0IjoxNzEzMjQ1MTc4LCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvYXV0aCIsInBhcmVudFJlZnJlc2hUb2tlbkhhc2gxIjpudWxsLCJyZWZyZXNoVG9rZW5IYXNoMSI6ImNkMjEwYzAzYWIyZmE0ZDMwM2FjYzFmOGQyMGM3MGJmZjUwYjNlYjkzMzkxMzFiMGQwYWE4Zjc4NDZmZGJlYWQiLCJzZXNzaW9uSGFuZGxlIjoiZTFlYjNmMzYtNTU0MC00Mzk5LTk0YTktMTRhMWU4NzAwOTQ2Iiwic3QtZXYiOnsidCI6MTcxMzI0NTE3ODg0OSwidiI6dHJ1ZX0sInN1YiI6IjY5ZjQ3MTI4LWQwY2UtNDZkNi05ODY1LWI5MzBkNWVlMTQ0OCIsInRJZCI6InB1YmxpYyJ9fQ==' \
  -H 'Origin: http://localhost:3000' \
  -H 'Referer: http://localhost:3000/' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-site' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36' \
  -H 'content-type: text/plain;charset=UTF-8' \
  -H 'rid: anti-csrf' \
  -H 'sec-ch-ua: "Google Chrome";v="123", "Not:A-Brand";v="8", "Chromium";v="123"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  -H 'st-auth-mode: cookie' \
  --data-raw '{"firstName":"Robert","lastName":"Usher","username":"rusher2"}' | jq "."
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   200  100   138  100    62    234    105 --:--:-- --:--:-- --:--:--   340
{
  "data": {
    "email": {
      "address": "rusher2004+jbdev2@gmail.com",
      "verified": true
    },
    "firstName": "Robert",
    "lastName": "Usher",
    "username": "rusher2"
  }
}
```

Successful failure to call `PUT /user/rusher`

```sh
curl 'http://localhost:8080/user/rusher' \ 
  -X 'PUT' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Cookie: sAccessToken=eyJraWQiOiJkLTE3MTMwMjIyNDI5NjQiLCJ0eXAiOiJKV1QiLCJ2ZXJzaW9uIjoiNCIsImFsZyI6IlJTMjU2In0.eyJpYXQiOjE3MTMyNDUxNzgsImV4cCI6MTcxMzI0ODY1OSwic3ViIjoiNjlmNDcxMjgtZDBjZS00NmQ2LTk4NjUtYjkzMGQ1ZWUxNDQ4IiwidElkIjoicHVibGljIiwic2Vzc2lvbkhhbmRsZSI6ImUxZWIzZjM2LTU1NDAtNDM5OS05NGE5LTE0YTFlODcwMDk0NiIsInJlZnJlc2hUb2tlbkhhc2gxIjoiY2QyMTBjMDNhYjJmYTRkMzAzYWNjMWY4ZDIwYzcwYmZmNTBiM2ViOTMzOTEzMWIwZDBhYThmNzg0NmZkYmVhZCIsInBhcmVudFJlZnJlc2hUb2tlbkhhc2gxIjpudWxsLCJhbnRpQ3NyZlRva2VuIjpudWxsLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvYXV0aCIsInN0LWV2Ijp7InQiOjE3MTMyNDUxNzg4NDksInYiOnRydWV9fQ.R8A9dvAgHruEsLC83W1oSqrPjGWWReuLmW6kRpR58s3xiKUnVBj5dF6gGzpORdPMd3qhgo0rKR7prNc_6uH6JOosplENqkoyceC1yGzIDtIe0ppaK222GAE3BHxakEO167_qP9gu2aZU_u5SnqILzj3iG2VtcroDaDgosFot_y8-bJzY6KnlVgEhftqV2jiyrNYB_p-3hQ4YtaF0ELFeZzNTqmFy7iWzh-_D4Z6lxaUjkAay24P7ZdmiSeEppLdcVZL9jvM_MsPSj-o9ILW_jzmGPRhsCRo4ufDdJhZYvT2QvnkcNRM1BuZ-9s5VQRslMwMPAXw2ATdB0YOROOQJKg; st-last-access-token-update=1713245179111; sFrontToken=eyJ1aWQiOiI2OWY0NzEyOC1kMGNlLTQ2ZDYtOTg2NS1iOTMwZDVlZTE0NDgiLCJhdGUiOjE3MTMyNDg2NTkwMDAsInVwIjp7ImFudGlDc3JmVG9rZW4iOm51bGwsImV4cCI6MTcxMzI0ODY1OSwiaWF0IjoxNzEzMjQ1MTc4LCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvYXV0aCIsInBhcmVudFJlZnJlc2hUb2tlbkhhc2gxIjpudWxsLCJyZWZyZXNoVG9rZW5IYXNoMSI6ImNkMjEwYzAzYWIyZmE0ZDMwM2FjYzFmOGQyMGM3MGJmZjUwYjNlYjkzMzkxMzFiMGQwYWE4Zjc4NDZmZGJlYWQiLCJzZXNzaW9uSGFuZGxlIjoiZTFlYjNmMzYtNTU0MC00Mzk5LTk0YTktMTRhMWU4NzAwOTQ2Iiwic3QtZXYiOnsidCI6MTcxMzI0NTE3ODg0OSwidiI6dHJ1ZX0sInN1YiI6IjY5ZjQ3MTI4 <....
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   110  100    48  100    62   1452   1876 --:--:-- --:--:-- --:--:--  3235
{
  "error": "accountOwner does not match request"
}
```